### PR TITLE
Add metrics role

### DIFF
--- a/hugo/content/installation/installing-metrics.md
+++ b/hugo/content/installation/installing-metrics.md
@@ -1,0 +1,99 @@
+---
+title: "Installing Metrics Stack"
+date:
+draft: false
+weight: 40
+---
+
+# Installing
+
+The following assumes the proper [prerequisites are satisfied](/getting-started/prerequisites)
+we can now install the PostgreSQL Operator.
+
+## Installing on Linux
+
+On a Linux host with Ansible installed we can run the following command to install 
+the Metrics stack:
+
+The following command should be run from the directory where the
+`postgres-operator-playbooks` project is located:
+
+```bash
+ansible-playbook -i /path/to/inventory main.yml --tags=install-metrics
+```
+
+## Installing on MacOS
+
+On a MacOS host with Ansible installed we can run the following command to install 
+the Metrics stack:
+
+The following command should be run from the directory where the
+`postgres-operator-playbooks` project is located:
+
+```bash
+ansible-playbook -i /path/to/inventory main.yml --tags=install-metrics
+```
+
+## Installing on Windows
+
+On a Windows host with a Cygwin terminal we can run the following commands to install 
+the Metrics stack:
+
+First, run the following command to setup the `ansible_python_interpreter` for 
+Cygwin:
+
+```bash
+sed -i 's~/usr/bin/env python~/usr/bin/env.exe python3.6~g' /path/to/inventory
+```
+
+The following command should be run from the directory where the
+`postgres-operator-playbooks` project is located:
+
+```bash
+ansible-playbook -i /path/to/inventory main.yml --tags=install-metrics
+```
+
+## Verifying the Installation
+
+This may take a few minutes to deploy.  To check the status of the deployment run 
+the following:
+
+```bash
+# Kubernetes
+kubectl get deployments -n <NAMESPACE_NAME>
+kubectl get pods -n <NAMESPACE_NAME>
+
+# OpenShift
+oc get deployments -n <NAMESPACE_NAME>
+oc get pods -n <NAMESPACE_NAME>
+```
+
+## Verify Grafana
+
+In a separate terminal we need to setup a port forward to the Crunchy Grafana deployment 
+to ensure connection can be made outside of the cluster:
+
+```bash
+# If deployed to Kubernetes
+kubectl port-forward <GRAFANA_POD_NAME> -n <METRICS_NAMESPACE> 3000:3000
+
+# If deployed to OpenShift
+oc port-forward <GRAFANA_POD_NAME> -n <METRICS_NAMESPACE> 3000:3000
+```
+
+In a browser navigate to `https://127.0.0.1:3000` to access the Grafana dashboard.
+
+## Verify Prometheus
+
+In a separate terminal we need to setup a port forward to the Crunchy Prometheus deployment 
+to ensure connection can be made outside of the cluster:
+
+```bash
+# If deployed to Kubernetes
+kubectl port-forward <PROMETHEUS_POD_NAME> -n <METRICS_NAMESPACE> 9090:9090
+
+# If deployed to OpenShift
+oc port-forward <PROMETHEUS_POD_NAME> -n <METRICS_NAMESPACE> 9090:9090
+```
+
+In a browser navigate to `https://127.0.0.1:9090` to access the Prometheus dashboard.

--- a/hugo/content/installation/installing-operator.md
+++ b/hugo/content/installation/installing-operator.md
@@ -78,12 +78,15 @@ to configure local environment variables before using the `pgo` client.
 To configure the environment variables used by `pgo` on a Linux or MacOS host, 
 run the following command:
 
+Note: `<PGO_NAMESPACE>` should be replaced with the namespace the Crunchy PostgreSQL
+Operator was deployed to.
+
 ```bash
 cat <<EOF >> ~/.bashrc
-export PGOUSER="~/.pgo/pgouser"
-export PGO_CA_CERT="~/.pgo/client.crt"
-export PGO_CLIENT_CERT="~/.pgo/client.crt"
-export PGO_CLIENT_KEY="~/.pgo/client.pem"
+export PGOUSER="~/.pgo/<PGO_NAMESPACE>/pgouser"
+export PGO_CA_CERT="~/.pgo/<PGO_NAMESPACE>/client.crt"
+export PGO_CLIENT_CERT="~/.pgo/<PGO_NAMESPACE>/client.crt"
+export PGO_CLIENT_KEY="~/.pgo/<PGO_NAMESPACE>/client.pem"
 export PGO_APISERVER_URL=https://127.0.0.1:8443
 EOF
 ```
@@ -99,12 +102,15 @@ source ~/.bashrc
 To configure the environment variables used by `pgo` on a Windows (Cygwin) host,
 run the following command:
 
+Note: `<PGO_NAMESPACE>` should be replaced with the namespace the Crunchy PostgreSQL 
+Operator was deployed to.
+
 ```bash
 cat <<EOF >> ~/.bashrc
-export PGOUSER="$(cygpath -w ~/.pgo/pgouser)"
-export PGO_CA_CERT="$(cygpath -w ~/.pgo/client.crt)"
-export PGO_CLIENT_CERT="$(cygpath -w ~/.pgo/client.crt)"
-export PGO_CLIENT_KEY="$(cygpath -w ~/.pgo/client.pem)"
+export PGOUSER="$(cygpath -w ~/.pgo/<PGO_NAMESPACE>/pgouser)"
+export PGO_CA_CERT="$(cygpath -w ~/.pgo/<PGO_NAMESPACE>/client.crt)"
+export PGO_CLIENT_CERT="$(cygpath -w ~/.pgo/<PGO_NAMESPACE>/client.crt)"
+export PGO_CLIENT_KEY="$(cygpath -w ~/.pgo/<PGO_NAMESPACE>/client.pem)"
 export PGO_APISERVER_URL="https://127.0.0.1:8443"
 EOF
 ```

--- a/hugo/content/prereq/prerequisites.md
+++ b/hugo/content/prereq/prerequisites.md
@@ -43,15 +43,22 @@ The following are the variables available for configuration:
 | `db_port`                         | 5432        | Set to configure the default port used on all newly created clusters.                                                                                                            |
 | `db_replicas`                     | 1           | Set to configure the amount of replicas provisioned on all newly created clusters.                                                                                               |
 | `db_user`                         | testuser    | Set to configure the username of the dedicated user account on all newly created clusters.                                                                                       |
+| `grafana_admin_username`          | admin       | Set to configure the login username for the Grafana administrator.														     |
+| `grafana_admin_password`          |             | Set to configure the login password for the Grafana administrator.														     |
+| `grafana_install`                 | true        | Set to true to install Crunchy Grafana to visualize metrics.                                                                                                                     |
+| `grafana_storage_access_mode`     |             | Set to the access mode used by the configured storage class for Grafana persistent volumes.                                                                                      |
+| `grafana_storage_class_name`      |             | Set to the name of the storage class used when creating Grafana persistent volumes.                                                                                              |
+| `grafana_volume_size`             |             | Set to the size of persistent volume to create for Grafana.                                                                                                                      |
 | `kubernetes_context`              |             | When deploying to Kubernetes, set to configure the context name of the kubeconfig to be used for authentication.                                                                 |
 | `log_statement`                   | none        | Set to `none`, `ddl`, `mod`, or `all` to configure the statements that will be logged in PostgreSQL's logs on all newly created clusters.                                        |
 | `metrics`                         | false       | Set to true enable performance metrics on all newly created clusters.                                                                                                            |
+| `metrics_namespace`               | metrics     | Configures the target namespace when deploying Grafana and/or Prometheus                                                                                                         |
 | `openshift_host`                  |             | When deploying to OpenShift, set to configure the hostname of the OpenShift cluster to connect to.                                                                               |
 | `openshift_password`              |             | When deploying to OpenShift, set to configure the password used for login.                                                                                                       |
 | `openshift_skip_tls_verify`       |             | When deploying to Openshift, set to ignore the integrity of TLS certificates for the OpenShift cluster.                                                                          |
 | `openshift_token`                 |             | When deploying to OpenShift, set to configure the token used for login (when not using username/password authentication).                                                        |
 | `openshift_user`                  |             | When deploying to OpenShift, set to configure the username used for login.                                                                                                       |
-| `pgo_install_client`              | true        | Configures the playbooks to install the `pgo` client if set to true.                                                                                                             |
+| `pgo_client_install`              | true        | Configures the playbooks to install the `pgo` client if set to true.                                                                                                             |
 | `pgo_image_prefix`                | crunchydata | Configures the image prefix used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc).                                             |
 | `pgo_image_tag`                   |             | Configures the image tag used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc)                                                 |
 | `pgo_namespace`                   |             | Set to configure the namespace where Operator will be deployed.                                                                                                                  |
@@ -59,6 +66,10 @@ The following are the variables available for configuration:
 | `pgo_tls_no_verify`               |             | Set to configure Operator to verify TLS certificates.                                                                                                                            |
 | `pgo_username`                    | admin       | Configures the pgo administrator username.                                                                                                                                       |
 | `primary_storage`                 | storage2    | Set to configure which storage definition to use when creating volumes used by PostgreSQL primaries on all newly created clusters.                                               |
+| `prometheus_install`              | true        | Set to true to install Crunchy Prometheus timeseries database.                                                                                                                   |
+| `prometheus_storage_access_mode`  |             | Set to the access mode used by the configured storage class for Prometheus persistent volumes.                                                                                   |
+| `prometheus_storage_class_name`   |             | Set to the name of the storage class used when creating Prometheus persistent volumes.                                                                                           |
+| `grafana_volume_size`             |             | Set to the size of persistent volume to create for Grafana.                                                                                                                      |
 | `replica_storage`                 | storage3    | Set to configure which storage definition to use when creating volumes used by PostgreSQL replicas on all newly created clusters.                                                |
 | `scheduler_timeout`               | 3600        | Set to a value in seconds to configure the `pgo-scheduler` timeout threshold when waiting for schedules to complete.                                                             |
 | `service_type`                    | ClusterIP   | Set to configure the type of Kubernetes service provisioned on all newly created clusters.                                                                                       |
@@ -191,3 +202,22 @@ target_namespaces='pgo2,pgo3'
 
 Each install of the operator will create a corresponding directory in `$HOME/.pgo/<PGO NAMESPACE>` which will contain 
 the TLS and `pgouser` client credentials.
+
+## Deploying Grafana and Prometheus
+
+PostgreSQL clusters created by the operator can be configured to create additional containers for collecting metrics.  
+These metrics are very useful for understanding the overall health and performance of PostgreSQL database deployments 
+over time.  The collectors included by the operator are:
+
+* Node Exporter - Host metrics where the PostgreSQL containers are running
+* PostgreSQL Exporter - PostgreSQL metrics
+
+The operator, however, does not install the neccessary timeseries database (Prometheus) for storing the collected 
+metrics or the front end visualization (Grafana) of those metrics.
+
+Included in these playbooks are roles for deploying Granfana and/or Prometheus.  See the `inventory` file 
+for options to install the metrics stack.
+
+{{% notice tip %}}
+At this time the Crunchy PostgreSQL Operator Playbooks only support storage classes.
+{{% /notice %}}

--- a/hugo/content/uninstall/uninstalling-metrics.md
+++ b/hugo/content/uninstall/uninstalling-metrics.md
@@ -1,0 +1,21 @@
+---
+title: "Uninstalling Metrics Stack"
+date:
+draft: false
+weight: 50
+---
+
+# Uninstalling the Metrics Stack
+
+The following assumes the proper [prerequisites are satisfied](/getting-started/prerequisites)
+we can now deprovision the PostgreSQL Operator.
+
+First, it is recommended to use the playbooks tagged with the same version
+of the Metrics stack currently deployed.
+
+With the correct playbooks acquired and prerequisites satisfied, simply run
+the following command:
+
+```bash
+ansible-playbook -i /path/to/inventory main.yml --tags=deprovision-metrics
+```

--- a/inventory
+++ b/inventory
@@ -4,6 +4,13 @@ localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env pyth
 
 crunchy_debug='false'
 
+# ===================
+# PGO Settings
+# The following settings configure the Crunchy PostgreSQL Operator 
+# functionality.
+# ===================
+pgo_client_install='true'
+
 # PGO Namespace
 pgo_namespace='pgo'
 target_namespaces='pgo'
@@ -21,7 +28,7 @@ ccp_image_tag='centos7-11.2-2.3.1'
 
 # Crunchy PostgreSQL Operator images to use.  The tags centos7 and rhel7 are acceptable.
 pgo_image_prefix='crunchydata'
-pgo_image_tag='centos7-4.0.0-rc2'
+pgo_image_tag='centos7-4.0.0-rc3'
 
 # This will set default enhancements for operator deployed PostgreSQL clusters
 auto_failover='false'
@@ -44,6 +51,7 @@ auto_failover_sleep_secs=9
 # Scheduler Settings
 scheduler_timeout=3600
 
+# ===================
 # PostgreSQL Settings
 # Default parameters for objects created when the database container starts
 # such as: default database name and default username
@@ -52,9 +60,29 @@ db_name='userdb'
 db_password_age_days=60
 db_password_length=20
 db_port=5432
-db_replicas=1
+db_replicas=0
 db_user='testuser'
 
+# ==================
+# Metrics
+# ==================
+# Optional installation of Grafana and Prometheus optimized 
+# to work with the Crunchy PostgreSQL Operator
+metrics_namespace='metrics'
+
+grafana_install='true'
+grafana_admin_username='admin'
+grafana_admin_password=''
+#grafana_storage_access_mode='ReadWriteOnce'
+#grafana_storage_class_name='fast'
+#grafana_volume_size='1G'
+
+prometheus_install='true'
+#prometheus_storage_access_mode='ReadWriteOnce'
+#prometheus_storage_class_name='fast'
+#prometheus_volume_size='1G'
+
+# ==================
 # Storage Settings
 # ==================
 # Which storage definitions to use when creating persistent volumes
@@ -88,14 +116,16 @@ storage3_class='fast'
 #storage3_supplemental_groups=65534
 #storage3_fs_group=26
 
+# ==================
 # Deploy into Openshift
 # Note: openshift_token can be used for token authentication
-# =====================
+# ==================
 # openshift_host=''
 # openshift_skip_tls_verify=true
 # openshift_user=''
 # openshift_password=''
 
+# ==================
 # Deploy into Kubernetes
-# =====================
+# ==================
 # kubernetes_context=''

--- a/main.yml
+++ b/main.yml
@@ -7,3 +7,4 @@
   roles:
     - preflight 
     - operator
+    - metrics

--- a/roles/metrics/defaults/main.yml
+++ b/roles/metrics/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+grafana_default_dashboards: "true"
+grafana_port: "3000"
+grafana_service_name: "crunchy-grafana"
+
+metrics_namespace: "crunchy-metrics"
+
+prometheus_port: "9090"
+prometheus_service_name: "crunchy-prometheus"

--- a/roles/metrics/tasks/cleanup.yml
+++ b/roles/metrics/tasks/cleanup.yml
@@ -1,0 +1,79 @@
+---
+- name: Use kubectl or oc
+  set_fact:
+    kubectl_or_oc: "{{ openshift_oc_bin if openshift_oc_bin is defined else 'kubectl' }}"
+  tags:
+  - deprovision-metrics
+  - upgrade-metrics
+
+- name: Delete Prometheus Deployment
+  shell: |
+    {{ kubectl_or_oc }} delete deployment crunchy-prometheus -n {{ metrics_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics
+
+- name: Delete Grafana Deployment
+  shell: |
+    {{ kubectl_or_oc }} delete deployment crunchy-grafana -n {{ metrics_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics
+
+- name: Delete Prometheus Service
+  shell: |
+    {{ kubectl_or_oc }} delete service {{ prometheus_service_name }} -n {{ metrics_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics
+
+- name: Delete Grafana Service 
+  shell: |
+    {{ kubectl_or_oc }} delete service {{ grafana_service_name }} -n {{ metrics_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics
+
+- name: Delete Prometheus Cluster Roles 
+  shell: |
+    {{ kubectl_or_oc }} delete clusterrole,clusterrolebinding {{ metrics_namespace }}-prometheus-sa -n {{ metrics_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics
+
+- name: Delete Prometheus Service Account
+  shell: |
+    {{ kubectl_or_oc }} delete serviceaccount prometheus-sa -n {{ metrics_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics
+
+- name: Delete Grafana PVC
+  shell: |
+    {{ kubectl_or_oc }} delete pvc grafanadata -n {{ metrics_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics
+
+- name: Delete Prometheus PVC
+  shell: |
+    {{ kubectl_or_oc }} delete pvc prometheusdata -n {{ metrics_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics
+
+- name: Delete Grafana Secret
+  shell: |
+    {{ kubectl_or_oc }} delete secret grafana-secret -n {{ metrics_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics

--- a/roles/metrics/tasks/grafana.yml
+++ b/roles/metrics/tasks/grafana.yml
@@ -1,0 +1,54 @@
+---
+- fail:
+    msg: "Only set one of kubernetes_context or openshift_host"
+  when: openshift_host is defined and kubernetes_context is defined
+  tags: always
+
+- name: Set output directory fact
+  set_fact:
+    grafana_output_dir: "./output/{{ metrics_namespace }}"
+  tags: always
+
+- name: Ensure output directory exists
+  file: 
+    path: "{{ grafana_output_dir }}"
+    state: directory
+    mode: 0700
+  tags: always
+
+- name: Use kubectl or oc
+  set_fact:
+    kubectl_or_oc: "{{ openshift_oc_bin if openshift_oc_bin is defined else 'kubectl' }}"
+  tags: always
+
+- name: Deploy Grafana
+  block:
+    - name: Template Grafana Secret
+      template:
+        src: "grafana-secret.json.j2"
+        dest: "{{ grafana_output_dir }}/grafana-secret.json"
+        mode: '0600'
+      tags: [install-metrics]
+
+    - name: Create Grafana Secret
+      command: "{{ kubectl_or_oc }} create -f {{ grafana_output_dir }}/grafana-secret.json -n {{ metrics_namespace }}"
+      tags: [install-metrics]
+
+    - name: Template Grafana Deployment
+      template:
+        src: "{{ item }}"
+        dest: "{{ grafana_output_dir }}/{{ item | replace('.j2', '') }}"
+        mode: '0600'
+      with_items: 
+      - grafana-pvc.json.j2
+      - grafana-service.json.j2
+      - grafana-deployment.json.j2
+      tags: [install-metrics]
+
+    - name: Create Grafana Deployment
+      command: "{{ kubectl_or_oc }} create -f {{ grafana_output_dir }}/{{ item }} -n {{ metrics_namespace }}"
+      with_items:
+      - grafana-pvc.json
+      - grafana-service.json
+      - grafana-deployment.json
+      tags: [install-metrics]

--- a/roles/metrics/tasks/kubernetes.yml
+++ b/roles/metrics/tasks/kubernetes.yml
@@ -1,0 +1,11 @@
+---
+- name: Get Namespace Details
+  shell: "kubectl get namespace {{ metrics_namespace }}" 
+  register: namespace_details
+  ignore_errors: yes
+  tags: install-metrics
+
+- name: Create Namespace {{ metrics_namespace }}
+  shell: "kubectl create namespace {{ metrics_namespace }}"
+  when: namespace_details.rc != 0
+  tags: install-metrics

--- a/roles/metrics/tasks/kubernetes_auth.yml
+++ b/roles/metrics/tasks/kubernetes_auth.yml
@@ -1,0 +1,4 @@
+---
+- name: Set the Kubernetes Context
+  shell: "kubectl config set-context {{ kubernetes_context }}"
+  tags: always

--- a/roles/metrics/tasks/main.yml
+++ b/roles/metrics/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- include_tasks: "preflight.yml"
+  tags: always
+
+- include_tasks: "{{ tasks }}"
+  with_items:
+    - openshift_auth.yml
+    - openshift.yml
+  loop_control:
+    loop_var: tasks
+  when: openshift_host is defined
+  tags: always
+
+- include_tasks: "{{ tasks }}"
+  with_items:
+    - kubernetes_auth.yml
+    - kubernetes.yml
+  loop_control:
+    loop_var: tasks
+  when: kubernetes_context is defined
+  tags: always
+
+- include_tasks: cleanup.yml
+  tags: [deprovision-metrics, upgrade-metrics]
+
+- name: Use kubectl or oc
+  set_fact:
+    kubectl_or_oc: "{{ openshift_oc_bin if openshift_oc_bin is defined else 'kubectl' }}"
+  tags: always
+
+- include_tasks: prometheus.yml
+  when: prometheus_install == "true"
+  tags: always
+
+- include_tasks: grafana.yml
+  when: grafana_install == "true"
+  tags: always

--- a/roles/metrics/tasks/openshift.yml
+++ b/roles/metrics/tasks/openshift.yml
@@ -1,0 +1,11 @@
+---
+- name: Get Project Details
+  shell: "{{ openshift_oc_bin}} get project {{ metrics_namespace }}"
+  register: namespace_details
+  ignore_errors: yes
+  tags: install-metrics
+
+- name: Create Project {{ metrics_namespace }}
+  shell: "{{ openshift_oc_bin}} new-project {{ metrics_namespace }}"
+  when: namespace_details.rc != 0
+  tags: install-metrics

--- a/roles/metrics/tasks/openshift_auth.yml
+++ b/roles/metrics/tasks/openshift_auth.yml
@@ -1,0 +1,25 @@
+---
+- include_vars: openshift.yml
+  tags: always
+
+- name: Authenticate with OpenShift via user and password
+  shell: |
+    {{ openshift_oc_bin }} login {{ openshift_host }} \
+      -u {{ openshift_user }} \
+      -p {{ openshift_password }} \
+      --insecure-skip-tls-verify={{ openshift_skip_tls_verify | default(false) | bool }}
+  when:
+    - openshift_user is defined and openshift_user != ''
+    - openshift_password is defined and openshift_password != ''
+    - openshift_token is not defined
+  no_log: false
+  tags: always
+
+- name: Authenticate with OpenShift via token
+  shell: |
+    {{ openshift_oc_bin }} login {{ openshift_host }} \
+      --token {{ openshift_token }} \
+      --insecure-skip-tls-verify={{ openshift_skip_tls_verify | default(false) | bool }}
+  when: openshift_token is defined and openshift_token != ''
+  no_log: true
+  tags: always

--- a/roles/metrics/tasks/preflight.yml
+++ b/roles/metrics/tasks/preflight.yml
@@ -1,0 +1,28 @@
+---
+- name: Check if inventory file variables are defined for Prometheus
+  fail: msg="Please specify the value of {{item}} in your inventory file"
+  tags: always
+  when: "item is undefined or item == '' and prometheus_install == 'true'"
+  with_items:
+  - metrics_namespace
+  - prometheus_service_name
+  - prometheus_port
+  - prometheus_storage_access_mode
+  - prometheus_storage_class_name
+  - prometheus_volume_size
+
+- name: Check if inventory file variables are defined for Grafana
+  fail: msg="Please specify the value of {{item}} in your inventory file"
+  tags: always
+  when: "item is undefined or item == '' and grafana_install == 'true'"
+  with_items:
+  - metrics_namespace
+  - grafana_install
+  - grafana_admin_username
+  - grafana_admin_password
+  - grafana_port
+  - grafana_service_name
+  - grafana_default_dashboards
+  - grafana_storage_access_mode
+  - grafana_storage_class_name
+  - grafana_volume_size

--- a/roles/metrics/tasks/prometheus.yml
+++ b/roles/metrics/tasks/prometheus.yml
@@ -1,0 +1,45 @@
+---
+- fail:
+    msg: "Only set one of kubernetes_context or openshift_host"
+  when: openshift_host is defined and kubernetes_context is defined
+  tags: always
+
+- name: Set output directory fact
+  set_fact:
+    prom_output_dir: "./output/{{ metrics_namespace }}"
+  tags: always
+
+- name: Ensure output directory exists
+  file: 
+    path: "{{ prom_output_dir }}"
+    state: directory
+    mode: 0700
+  tags: always
+
+- name: Use kubectl or oc
+  set_fact:
+    kubectl_or_oc: "{{ openshift_oc_bin if openshift_oc_bin is defined else 'kubectl' }}"
+  tags: always
+
+- name: Deploy Prometheus
+  block:
+    - name: Template Prometheus Objects
+      template:
+        src: "{{ item }}"
+        dest: "{{ prom_output_dir }}/{{ item | replace('.j2', '') }}"
+        mode: '0600'
+      with_items: 
+      - prometheus-pvc.json.j2
+      - prometheus-rbac.json.j2
+      - prometheus-service.json.j2
+      - prometheus-deployment.json.j2
+      tags: [install-metrics]
+
+    - name: Create Prometheus Objects
+      command: "{{ kubectl_or_oc }} create -f {{ prom_output_dir }}/{{ item }} -n {{ metrics_namespace }}"
+      with_items:
+      - prometheus-pvc.json
+      - prometheus-rbac.json
+      - prometheus-service.json
+      - prometheus-deployment.json
+      tags: [install-metrics]

--- a/roles/metrics/templates/grafana-deployment.json.j2
+++ b/roles/metrics/templates/grafana-deployment.json.j2
@@ -1,0 +1,89 @@
+{
+    "apiVersion": "extensions/v1beta1",
+    "kind": "Deployment",
+    "metadata": {
+        "name": "crunchy-grafana"
+    },
+    "spec": {
+        "replicas": 1,
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "{{ grafana_service_name }}",
+                    "vendor": "crunchydata"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "grafana",
+                        "image": "{{ ccp_image_prefix }}/crunchy-grafana:{{ ccp_image_tag }}",
+                        "ports": [
+                            {
+                                "containerPort": {{ grafana_port }},
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "tcpSocket": {
+                                "port": {{ grafana_port }}
+                            },
+                            "initialDelaySeconds": 20,
+                            "periodSeconds": 10
+                        },
+                        "livenessProbe": {
+                            "tcpSocket": {
+                                "port": {{ grafana_port }}
+                            },
+                            "initialDelaySeconds": 25,
+                            "periodSeconds": 20
+                        },
+                        "env": [
+                            {
+                                "name": "ADMIN_USER",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "grafana-secret",
+                                        "key": "username"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "ADMIN_PASS",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "grafana-secret",
+                                        "key": "password"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "PROM_HOST",
+                                "value": "{{ prometheus_service_name }}"
+                            },
+                            {
+                                "name": "PROM_PORT",
+                                "value": "{{ prometheus_port }}"
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/data",
+                                "name": "grafanadata",
+                                "readOnly": false
+                            }
+                        ]
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "grafanadata",
+                        "persistentVolumeClaim": {
+                            "claimName": "grafanadata"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/roles/metrics/templates/grafana-pvc.json.j2
+++ b/roles/metrics/templates/grafana-pvc.json.j2
@@ -1,0 +1,18 @@
+{
+    "kind": "PersistentVolumeClaim",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "grafanadata"
+    },
+    "spec": {
+        "accessModes": [
+            "{{ grafana_storage_access_mode }}"
+        ],
+        "storageClassName": "{{ grafana_storage_class_name }}",
+        "resources": {
+            "requests": {
+                "storage": "{{ grafana_volume_size }}"
+            }
+        }
+    }
+}

--- a/roles/metrics/templates/grafana-secret.json.j2
+++ b/roles/metrics/templates/grafana-secret.json.j2
@@ -1,0 +1,12 @@
+{
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {
+        "name": "grafana-secret"
+    },
+    "type": "Opaque",
+    "stringData": {
+        "username": "{{ grafana_admin_username }}",
+        "password": "{{ grafana_admin_password }}"
+    }
+}

--- a/roles/metrics/templates/grafana-service.json.j2
+++ b/roles/metrics/templates/grafana-service.json.j2
@@ -1,0 +1,26 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "{{ grafana_service_name }}",
+        "labels": {
+            "name": "{{ grafana_service_name }}",
+            "vendor": "crunchydata"
+        }
+    },
+    "spec": {
+        "ports": [
+            {
+                "name": "grafana",
+                "protocol": "TCP",
+                "port": {{ grafana_port }},
+                "targetPort": {{ grafana_port }}
+            }
+        ],
+        "selector": {
+            "name": "{{ grafana_service_name }}"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+    }
+}

--- a/roles/metrics/templates/prometheus-deployment.json.j2
+++ b/roles/metrics/templates/prometheus-deployment.json.j2
@@ -1,0 +1,63 @@
+{
+    "apiVersion": "extensions/v1beta1",
+    "kind": "Deployment",
+    "metadata": {
+        "name": "crunchy-prometheus"
+    },
+    "spec": {
+        "replicas": 1,
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "{{ prometheus_service_name }}",
+                    "vendor": "crunchydata"
+                }
+            },
+            "spec": {
+                "serviceAccountName": "prometheus-sa",
+                "containers": [
+                    {
+                        "name": "prometheus",
+                        "image": "{{ ccp_image_prefix }}/crunchy-prometheus:{{ ccp_image_tag }}",
+                        "ports": [
+                            {
+                                "containerPort": {{ prometheus_port }},
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "tcpSocket": {
+                                "port": {{ prometheus_port }}
+                            },
+                            "initialDelaySeconds": 20,
+                            "periodSeconds": 10
+                        },
+                        "livenessProbe": {
+                            "tcpSocket": {
+                                "port": {{ prometheus_port }}
+                            },
+                            "initialDelaySeconds": 15,
+                            "periodSeconds": 20
+                        },
+                        "env": [],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/data",
+                                "name": "prometheusdata",
+                                "readOnly": false
+                            }
+                        ]
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "prometheusdata",
+                        "persistentVolumeClaim": {
+                            "claimName": "prometheusdata"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/roles/metrics/templates/prometheus-pvc.json.j2
+++ b/roles/metrics/templates/prometheus-pvc.json.j2
@@ -1,0 +1,18 @@
+{
+    "kind": "PersistentVolumeClaim",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "prometheusdata"
+    },
+    "spec": {
+        "accessModes": [
+            "{{ prometheus_storage_access_mode }}"
+        ],
+        "storageClassName": "{{ prometheus_storage_class_name }}",
+        "resources": {
+            "requests": {
+                "storage": "{{ prometheus_volume_size }}"
+            }
+        }
+    }
+}

--- a/roles/metrics/templates/prometheus-rbac.json.j2
+++ b/roles/metrics/templates/prometheus-rbac.json.j2
@@ -1,0 +1,51 @@
+{
+    "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+    "kind": "ClusterRole",
+    "metadata": {
+        "name": "{{ metrics_namespace }}-prometheus-sa"
+    },
+    "rules": [
+        {
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "pods"
+            ],
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ]
+        }
+    ]
+}
+
+{
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+        "name": "prometheus-sa",
+        "namespace": "{{ metrics_namespace }}"
+    }
+}
+
+{
+    "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+    "kind": "ClusterRoleBinding",
+    "metadata": {
+        "name": "{{ metrics_namespace }}-prometheus-sa"
+    },
+    "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "{{ metrics_namespace }}-prometheus-sa"
+    },
+    "subjects": [
+        {
+            "kind": "ServiceAccount",
+            "name": "prometheus-sa",
+            "namespace": "{{ metrics_namespace }}"
+        }
+    ]
+}

--- a/roles/metrics/templates/prometheus-service.json.j2
+++ b/roles/metrics/templates/prometheus-service.json.j2
@@ -1,0 +1,26 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "{{ prometheus_service_name }}",
+        "labels": {
+            "name": "{{ prometheus_service_name }}",
+            "vendor": "crunchydata"
+        }
+    },
+    "spec": {
+        "ports": [
+            {
+                "name": "prometheus",
+                "protocol": "TCP",
+                "port": {{ prometheus_port }},
+                "targetPort": {{ prometheus_port }}
+            }
+        ],
+        "selector": {
+            "name": "{{ prometheus_service_name }}"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+    }
+}

--- a/roles/metrics/vars/openshift.yml
+++ b/roles/metrics/vars/openshift.yml
@@ -1,0 +1,2 @@
+---
+openshift_oc_bin: "oc"

--- a/roles/operator/tasks/cleanup.yml
+++ b/roles/operator/tasks/cleanup.yml
@@ -28,8 +28,7 @@
   shell: |
     {{ kubectl_or_oc }} delete secret pgo-backrest-repo-config -n {{ item }}
   with_items:
-  - "{{ pgo_namespace }}"
-  - "{{ target_namespaces.split(',') }}"
+  - "{{ all_namespaces }}"
   ignore_errors: yes
   no_log: false
   tags:

--- a/roles/operator/tasks/preflight.yml
+++ b/roles/operator/tasks/preflight.yml
@@ -1,0 +1,38 @@
+---
+- name: Check if inventory file variables are defined
+  fail: msg="Please specify the value of {{item}} in your inventory file"
+  tags: always
+  when: "{{item}} is undefined or {{item}} == ''"
+  with_items:
+    - pgo_namespace
+    - target_namespaces
+    - pgo_username
+    - pgo_password
+    - ccp_image_prefix
+    - ccp_image_tag
+    - pgo_image_prefix
+    - pgo_image_tag
+    - auto_failover
+    - backrest
+    - badger
+    - metrics
+    - archive_mode
+    - archive_timeout
+    - auto_failover_sleep_secs
+    - db_password_age_days
+    - db_password_length
+    - db_port
+    - db_replicas
+    - db_user
+    - backup_storage
+    - primary_storage
+    - replica_storage
+    - storage1_access_mode
+    - storage1_size
+    - storage1_type
+    - storage2_access_mode
+    - storage2_size
+    - storage2_type
+    - storage3_access_mode
+    - storage3_size
+    - storage3_type

--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - fail:
-    msg: "Please specify the a tag: deprovision, install or upgrade"
+    msg: "Please specify the a tag: deprovision, deprovision-metrics, install, install-metrics or upgrade"
   tags: always
   when: ansible_run_tags[0] == "all"
 
@@ -21,41 +21,3 @@
 - include_tasks: check_kubernetes.yml
   when: kubernetes_context is defined and kubernetes_context != ''
   tags: always
-
-- name: Check if inventory file variables are defined
-  fail: msg="Please specify the value of {{item}} in your inventory file"
-  tags: always
-  when: "{{item}} is undefined or {{item}} == ''"
-  with_items:
-    - pgo_namespace
-    - target_namespaces
-    - pgo_username
-    - pgo_password
-    - ccp_image_prefix
-    - ccp_image_tag 
-    - pgo_image_prefix
-    - pgo_image_tag
-    - auto_failover
-    - backrest 
-    - badger
-    - metrics
-    - archive_mode 
-    - archive_timeout
-    - auto_failover_sleep_secs
-    - db_password_age_days
-    - db_password_length
-    - db_port
-    - db_replicas
-    - db_user
-    - backup_storage
-    - primary_storage
-    - replica_storage
-    - storage1_access_mode 
-    - storage1_size
-    - storage1_type
-    - storage2_access_mode 
-    - storage2_size
-    - storage2_type
-    - storage3_access_mode 
-    - storage3_size
-    - storage3_type


### PR DESCRIPTION
This adds the ability to install Grafana and Prometheus alongside of the Postgres Operator by adding a new role `metrics`.

Added two new tags to support this new role: `install-metrics` and `deprovision-metrics`.

[CH2246]